### PR TITLE
Added a missing period in the ~/.PyCharm path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This themes works with latest PyCharm editions.
 
 ## Installation
 
-To install themes, copy the `.ycls` files to `~/PyCharm[version]/config/colors`. Restart Pycharm IDE and go to:
+To install themes, copy the `.ycls` files to `~/.PyCharm[version]/config/colors`. Restart Pycharm IDE and go to:
 
 > View->Quick Switch Scheme->Color Scheme
 


### PR DESCRIPTION
Just added a missing period in the ~/.PyCharm path.

By the way, your repo of color schemes is really cool!  Thanks for sharing!